### PR TITLE
Update to latest golang, add RESTIC_JOB_ARGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV NFS_TARGET=""
 # By default backup every 6 hours
 ENV BACKUP_CRON="* */6 * * *"
 ENV RESTIC_FORGET_ARGS=""
+ENV RESTIC_JOB_ARGS=""
 
 # /data is the dir where you have to put the data to be backed up
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.7-alpine
+FROM golang:1.9-alpine
 MAINTAINER info@lobaro.com
 
-RUN echo http://nl.alpinelinux.org/alpine/v3.4/community >> /etc/apk/repositories
+RUN echo http://nl.alpinelinux.org/alpine/v3.6/community >> /etc/apk/repositories
 RUN apk add --no-cache git nfs-utils openssh fuse
 RUN git clone https://github.com/restic/restic \
   && cd restic \

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The container is setup by setting [environment variables](https://docs.docker.co
 * `RESTIC_PASSWORD` - the password for the restic repository. Will also be used for restic init during first start when the repository is not initialized.
 * `RESTIC_TAG` - Optional. To tag the images created by the container.
 * `NFS_TARGET` - Optional. If set the given NFS is mounted, i.e. `mount -o nolock -v ${NFS_TARGET} /mnt/restic`. `RESTIC_REPOSITORY` must remain it's default value!
-* `BACKUP_CRON` - A cron expression to run the backup. Default: `* */6 * * *` aka every 6 hours.
+* `BACKUP_CRON` - A cron expression to run the backup. Note: cron daemon uses UTC time zone. Default: `* */6 * * *` aka every 6 hours.
 * `RESTIC_FORGET_ARGS` - Optional. Only if specified `restic forget` is run with the given arguments after each backup. Example value: `-e "RESTIC_FORGET_ARGS=--prune --keep-last 10 --keep-hourly 24 --keep-daily 7 --keep-weekly 52 --keep-monthly 120 --keep-yearly 100"`
 
 ## Volumes

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The container is setup by setting [environment variables](https://docs.docker.co
 * `NFS_TARGET` - Optional. If set the given NFS is mounted, i.e. `mount -o nolock -v ${NFS_TARGET} /mnt/restic`. `RESTIC_REPOSITORY` must remain it's default value!
 * `BACKUP_CRON` - A cron expression to run the backup. Note: cron daemon uses UTC time zone. Default: `* */6 * * *` aka every 6 hours.
 * `RESTIC_FORGET_ARGS` - Optional. Only if specified `restic forget` is run with the given arguments after each backup. Example value: `-e "RESTIC_FORGET_ARGS=--prune --keep-last 10 --keep-hourly 24 --keep-daily 7 --keep-weekly 52 --keep-monthly 120 --keep-yearly 100"`
+* `RESTIC_JOB_ARGS` - Optional. Allows to specify extra arguments to the back up job such as limiting bandwith with `--limit-upload` or excluding file masks with `--exclude`.
 
 ## Volumes
 

--- a/backup.sh
+++ b/backup.sh
@@ -17,10 +17,11 @@ echo "Starting Backup at $(date)" >> ${lastLogfile}
 logLast "BACKUP_CRON: ${BACKUP_CRON}"
 logLast "RESTIC_TAG: ${RESTIC_TAG}"
 logLast "RESTIC_FORGET_ARGS: ${RESTIC_FORGET_ARGS}"
+logLast "RESTIC_JOB_ARGS: ${RESTIC_JOB_ARGS}"
 
 
 # Do not save full backup log to logfile but to backup-last.log
-restic backup /data --tag=${RESTIC_TAG?"Missing environment variable RESTIC_TAG"} >> ${lastLogfile} 2>&1
+restic backup /data ${RESTIC_JOB_ARGS} --tag=${RESTIC_TAG?"Missing environment variable RESTIC_TAG"} >> ${lastLogfile} 2>&1
 rc=$?
 logLast "Finished backup at $(date)"
 if [[ $rc == 0 ]]; then


### PR DESCRIPTION
This merge request will update the base golang to build latest restic version as well as add a `RESTIC_JOB_ARGS` environment variable.

It allows to specify extra options to the `restic backup` command.