### PR TITLE
Reduce layer count in Docker image:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
 FROM alpine as certs
 RUN apk add --no-cache ca-certificates
 
-
-FROM busybox:glibc
-
-COPY --from=certs /etc/ssl/certs /etc/ssl/certs
-
 # Get restic executable
 ENV RESTIC_VERSION=0.9.5
 ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 /
 RUN bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2 && mv restic_${RESTIC_VERSION}_linux_amd64 /bin/restic && chmod +x /bin/restic
 
-RUN mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log
+FROM busybox:glibc
 
-ENV RESTIC_REPOSITORY=/mnt/restic
-ENV RESTIC_PASSWORD=""
-ENV RESTIC_TAG=""
-ENV NFS_TARGET=""
-# By default backup every 6 hours
-ENV BACKUP_CRON="0 */6 * * *"
-ENV RESTIC_FORGET_ARGS=""
-ENV RESTIC_JOB_ARGS=""
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
+COPY --from=certs /bin/restic /bin/restic
+
+RUN \
+    mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \
+    touch /var/log/cron.log;
+
+ENV \
+    RESTIC_REPOSITORY=/mnt/restic \
+    RESTIC_PASSWORD="" \
+    RESTIC_TAG="" \
+    NFS_TARGET="" \
+    BACKUP_CRON="0 */6 * * *" \
+    RESTIC_FORGET_ARGS="" \
+    RESTIC_JOB_ARGS=""
 
 # /data is the dir where you have to put the data to be backed up
 VOLUME /data
@@ -28,7 +30,6 @@ VOLUME /data
 COPY backup.sh /bin/backup
 COPY entry.sh /entry.sh
 
-RUN touch /var/log/cron.log
 
 WORKDIR "/"
 


### PR DESCRIPTION
 * move the bzip2 file and extraction into the scratch image
 * combine commands and ENV directives to make less layers