### PR TITLE
Add rclone to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ ENV RESTIC_VERSION=0.9.5
 ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 /
 RUN bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2 && mv restic_${RESTIC_VERSION}_linux_amd64 /bin/restic && chmod +x /bin/restic
 
+FROM alpine as rclone
+
+# Get rclone executable
+ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
+RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/rclone && chmod +x /bin/rclone
+
 FROM busybox:glibc
 
 COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=certs /bin/restic /bin/restic
+COPY --from=rclone /bin/rclone /bin/rclone
 
 RUN \
     mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Since restic saves the hostname with each snapshot and the hostname of a docker 
 
 Either by setting the [environment variable](https://docs.docker.com/engine/reference/run/#env-environment-variables) `HOSTNAME` or with `--hostname` in the [network settings](https://docs.docker.com/engine/reference/run/#network-settings)
 
-## Backup to SFTP
+## Backup via SFTP
 
 Since restic needs a **password less login** to the SFTP server make sure you can do `sftp user@host` from inside the container. If you can do so from your host system, the easiest way is to just mount your `.ssh` folder conaining the authorized cert into the container by specifying `-v ~/.ssh:/root/.ssh` as argument for `docker run`.
 
@@ -97,6 +97,10 @@ Now you can simply specify the restic repository to be an [SFTP repository](http
 ```
 -e "RESTIC_REPOSITORY=sftp:user@host:/tmp/backup"
 ```
+
+## Backup via rclone
+
+To use rclone as a backend for restic, simply add the rclone config file as a volume with `-v /absolute/path/to/rclone.conf:/root/.config/rclone/rclone.conf`.
 
 # Versioning & Changelog
 


### PR DESCRIPTION
I know this has been discussed here: https://github.com/lobaro/restic-backup-docker/issues/14
However, the rclone backend for restic is in my opinion very powerful as it enables way more backends than we had before. Therefore, I think it'd be nice to include this option!
And having an ~11 MB go binary added to the Docker image isn't that big of a deal compare to the advantages.