### PR TITLE
sftp repo checking wasn't working

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Either by setting the [environment variable](https://docs.docker.com/engine/refe
 
 ## Backup via SFTP
 
-Since restic needs a **password less login** to the SFTP server make sure you can do `sftp user@host` from inside the container. If you can do so from your host system, the easiest way is to just mount your `.ssh` folder conaining the authorized cert into the container by specifying `-v ~/.ssh:/root/.ssh` as argument for `docker run`.
+Since restic needs a **password less login** to the SFTP server make sure you can do `sftp user@host` from inside the container. If you can do so from your host system, the easiest way is to just mount your `.ssh` folder containing the authorized cert into the container by specifying `-v ~/.ssh:/root/.ssh` as argument for `docker run`.
 
 Now you can simply specify the restic repository to be an [SFTP repository](https://restic.readthedocs.io/en/stable/Manual/#create-an-sftp-repository).
 

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#!bin/bash
 
 echo "Starting container ..."
 
@@ -13,24 +13,35 @@ if [ -n "${NFS_TARGET}" ]; then
     mount -o nolock -v ${NFS_TARGET} /mnt/restic
 fi
 
-restic snapshots &>/dev/null
-status=$?
-echo "Check Repo status $status"
+if grep -q 'sftp:' $RESTIC_REPOSITORY; then
+        host_regex='^sftp:[^\s]+@([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):(.+)$'
+        [[ $RESTIC_REPOSITORY =~ $host_regex ]]
 
-if [ $status != 0 ]; then
-    echo "Restic repository '${RESTIC_REPOSITORY}' does not exist. Running restic init."
-    restic init
+        # Test whether the path exists on the remote repository. If not then create it.
+        if ssh ${BASH_REMATCH[1]} stat ${BASH_REMATCH[2]} \> /dev/null 2\>\&1; then
+                echo "Successfully found Restic repository '${RESTIC_REPOSITORY}'."
+            else
+                echo "Restic repository '${RESTIC_REPOSITORY}' does not exist. Running restic init."
+                restic init | true
+        fi
+    else
+        restic snapshots &>/dev/null
+        status=$?
+        echo "Check Repo status $status"
 
-    init_status=$?
-    echo "Repo init status $init_status"
+        if [ $status != 0 ]; then
+            echo "Restic repository '${RESTIC_REPOSITORY}' does not exist. Running restic init."
+            restic init
 
-    if [ $init_status != 0 ]; then
-        echo "Failed to init the repository: '${RESTIC_REPOSITORY}'"
-        exit 1
-    fi
+            init_status=$?
+            echo "Repo init status $init_status"
+
+            if [ $init_status != 0 ]; then
+                echo "Failed to init the repository: '${RESTIC_REPOSITORY}'"
+                exit 1
+            fi
+        fi
 fi
-
-
 
 echo "Setup backup cron job with cron expression BACKUP_CRON: ${BACKUP_CRON}"
 echo "${BACKUP_CRON} /bin/backup >> /var/log/cron.log 2>&1" > /var/spool/cron/crontabs/root

--- a/entry.sh
+++ b/entry.sh
@@ -14,7 +14,7 @@ if [ -n "${NFS_TARGET}" ]; then
 fi
 
 if grep -q 'sftp:' $RESTIC_REPOSITORY; then
-        host_regex='^sftp:[^\s]+@([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):(.+)$'
+        host_regex='^sftp:[^\s]+@(.+):(.+)$'
         [[ $RESTIC_REPOSITORY =~ $host_regex ]]
 
         # Test whether the path exists on the remote repository. If not then create it.

--- a/entry.sh
+++ b/entry.sh
@@ -18,7 +18,7 @@ status=$?
 echo "Check Repo status $status"
 
 if [ $status != 0 ]; then
-    echo "Restic repository '${RESTIC_REPOSITORY}' does not exists. Running restic init."
+    echo "Restic repository '${RESTIC_REPOSITORY}' does not exist. Running restic init."
     restic init
 
     init_status=$?


### PR DESCRIPTION
The implemented repo check worked great for nfs or local filesystems, but seemed to fall over when I connected to my remote repo. I believe this fix should work for both.

Fair warning, there's every chance i've both over-engineered the solution and under-engineered the regex... this isn't my area of expertise.