### PR TITLE
Run test backup every minute in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ echo "Start backup-test container. Backup of ~/test-data/ to repository ~/test-r
 docker run --privileged --name backup-test \
 -e "RESTIC_PASSWORD=test" \
 -e "RESTIC_TAG=test" \
--e "BACKUP_CRON=0 0 * * *" \
+-e "BACKUP_CRON=* * * * *" \
 -e "RESTIC_FORGET_ARGS=--keep-last 10" \
 -v ~/test-data:/data \
 -v ~/test-repo/:/mnt/restic \


### PR DESCRIPTION
Hi there,

Just to fix a small bug I noticed while testing:
I changed the interval of cron to backup every minute instead of once a day at
midnight to make it in line with the documentation.

See https://crontab.guru/#0_0_*_*_*