### PR TITLE
Base image directly on official restic image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as rclone
+FROM alpine:latest as rclone
 
 # Get rclone executable
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
@@ -8,6 +8,8 @@ FROM restic/restic:latest
 
 # install mailx
 RUN apk add --update --no-cache heirloom-mailx
+
+COPY --from=rclone /bin/rclone /bin/rclone
 
 RUN \
     mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,13 @@
-FROM alpine:3.10.1 as certs
-RUN apk add --no-cache ca-certificates
-
-# Get restic executable
-ENV RESTIC_VERSION=0.9.5
-ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 /
-RUN bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2 && mv restic_${RESTIC_VERSION}_linux_amd64 /bin/restic && chmod +x /bin/restic
-
 FROM alpine as rclone
 
 # Get rclone executable
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
 RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/rclone && chmod +x /bin/rclone
 
-FROM busybox:glibc
+FROM restic/restic:latest
 
 # install mailx
 RUN apk add --update --no-cache heirloom-mailx
-
-COPY --from=certs /etc/ssl/certs /etc/ssl/certs
-COPY --from=certs /bin/restic /bin/restic
-COPY --from=rclone /bin/rclone /bin/rclone
 
 RUN \
     mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \


### PR DESCRIPTION
Hi there,

while playing around with the image for my backup system I noticed that it didn't build (same as error as in #39). Instead of basing it on alpine linux as suggested I simply based it on the official restic image directly. This has the advantage of using Alpine Linux as base and having certs, ssh and fuse already installed.

I am not too familiar with Docker, so I don't know if this is a viable approach (for fixing #27, #29 and the build error in #39), but wanted to put it up for review. Maybe it's helpful :smile: 