### PR TITLE
Base image directly on official restic image with static version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as rclone
+FROM alpine:latest as rclone
 
 # Get rclone executable
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
@@ -8,6 +8,8 @@ FROM restic/restic:latest
 
 # install mailx
 RUN apk add --update --no-cache heirloom-mailx
+
+COPY --from=rclone /bin/rclone /bin/rclone
 
 RUN \
     mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,13 @@
-FROM alpine:3.10.1 as certs
-RUN apk add --no-cache ca-certificates
-
-# Get restic executable
-ENV RESTIC_VERSION=0.9.5
-ADD https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 /
-RUN bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2 && mv restic_${RESTIC_VERSION}_linux_amd64 /bin/restic && chmod +x /bin/restic
-
 FROM alpine as rclone
 
 # Get rclone executable
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
 RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/rclone && chmod +x /bin/rclone
 
-FROM busybox:glibc
+FROM restic/restic:latest
 
 # install mailx
 RUN apk add --update --no-cache heirloom-mailx
-
-COPY --from=certs /etc/ssl/certs /etc/ssl/certs
-COPY --from=certs /bin/restic /bin/restic
-COPY --from=rclone /bin/rclone /bin/rclone
 
 RUN \
     mkdir -p /mnt/restic /var/spool/cron/crontabs /var/log; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:latest as rclone
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
 RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/rclone && chmod +x /bin/rclone
 
-FROM restic/restic:latest
+FROM restic/restic:0.9.6
 
 # install mailx
 RUN apk add --update --no-cache heirloom-mailx


### PR DESCRIPTION
I took the initiative to expand on #41 based on @Niondir comment. So now we use restic:0.9.6 as base.

I hope it was not too rude :) 