### PR TITLE
Fix permission denied on OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ ENV RESTIC_JOB_ARGS=""
 ENV MAILX_ARGS=""
 
 # openshift fix
-RUN chgrp -R 0 /mnt && \
+RUN mkdir /.cache && \
+    chgrp -R 0 /.cache && \
+    chmod -R g=u /.cache && \
+    chgrp -R 0 /mnt && \
     chmod -R g=u /mnt && \
     chgrp -R 0 /var/spool/cron/crontabs/root && \
     chmod -R g=u /var/spool/cron/crontabs/root && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,14 @@ ENV RESTIC_FORGET_ARGS=""
 ENV RESTIC_JOB_ARGS=""
 ENV MAILX_ARGS=""
 
+# openshift fix
+RUN chgrp -R 0 /mnt && \
+    chmod -R g=u /mnt && \
+    chgrp -R 0 /var/spool/cron/crontabs/root && \
+    chmod -R g=u /var/spool/cron/crontabs/root && \
+    chgrp -R 0 /var/log/cron.log && \
+    chmod -R g=u /var/log/cron.log
+
 # /data is the dir where you have to put the data to be backed up
 VOLUME /data
 


### PR DESCRIPTION
OpenShift Container Platform runs containers using an arbitrarily assigned user ID instead of privileged user (root). Since the user inside the container is not root, it hasn't the permissions to perform some operations you do in the bootstrap script, like creating directory inside `/mnt` or setup the cron job.

This fix follows the [official OpenShift Container Platform guidelines](https://docs.openshift.com/container-platform/4.3/openshift_images/create-images.html#use-uid_create-images). It simply gives the needed permissions on the involved directories to users of the root group. Since the random user is in the root group, it will have the permissions to perform the operations, while basic users that are not in the root group still won't have permissions in order to preserve security.

**This pull request will allow OpenShift users to use your image.**  
I've successfully built and tested the new image on an OpenShift v4.4 cluster.  
You can find the [built image on the DockerHub](https://hub.docker.com/r/daquinoaldo/restic-backup-docker) (I'll remove it if you merge the PR).

This closes #47.