### PR TITLE
Add post-backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The container is setup by setting [environment variables](https://docs.docker.co
 * `AWS_ACCESS_KEY_ID` - Optional. When using restic with AWS S3 storage.
 * `AWS_SECRET_ACCESS_KEY` - Optional. When using restic with AWS S3 storage.
 * `MAILX_ARGS` - Optional. If specified, the content of `/var/log/backup-last.log` is sent via mail after each backup using an *external SMTP*. To have maximum flexibility, you have to specify the mail/smtp parameters by your own. Have a look at the [mailx manpage](https://linux.die.net/man/1/mailx) for further information. Example value: `-e "MAILX_ARGS=-r 'from@example.de' -s 'Result of the last restic backup run' -S smtp='smtp.example.com:587' -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user='username' -S smtp-auth-password='password' 'to@example.com'"`.
+* `POST_BACKUP_SCRIPT` - Optional. Allows a script to be run after backup. For example, running the docker container with `-v /myscript.sh:/bin/script.sh -e POST_BACKUP_SCRIPT=/bin/script.sh` will result in `/myscript.sh` being run after the backup.
 
 ## Volumes
 

--- a/backup.sh
+++ b/backup.sh
@@ -52,6 +52,11 @@ fi
 end=`date +%s`
 echo "Finished Backup at $(date +"%Y-%m-%d %H:%M:%S") after $((end-start)) seconds"
 
+if [ -n "$POST_BACKUP_SCRIPT" -a -f "$POST_BACKUP_SCRIPT" ]; then
+    echo "Starting ${POST_BACKUP_SCRIPT}"
+    "$POST_BACKUP_SCRIPT" >> ${lastLogfile} 2>&1
+fi
+
 if [ -n "${MAILX_ARGS}" ]; then
     sh -c "mailx -v -S sendwait ${MAILX_ARGS} < ${lastLogfile} > ${lastMailLogfile} 2>&1"
     if [ $? == 0 ]; then


### PR DESCRIPTION
Add an optional `POST_BACKUP_SCRIPT` environment variable to allow running a script after the backup.