### PR TITLE
Add Microsoft Teams notification channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/
 FROM restic/restic:0.9.6
 
 # install mailx
-RUN apk add --update --no-cache heirloom-mailx fuse
+RUN apk add --update --no-cache heirloom-mailx fuse curl
 
 COPY --from=rclone /bin/rclone /bin/rclone
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The container is setup by setting [environment variables](https://docs.docker.co
 * `RESTIC_JOB_ARGS` - Optional. Allows to specify extra arguments to the back up job such as limiting bandwith with `--limit-upload` or excluding file masks with `--exclude`.
 * `AWS_ACCESS_KEY_ID` - Optional. When using restic with AWS S3 storage.
 * `AWS_SECRET_ACCESS_KEY` - Optional. When using restic with AWS S3 storage.
+* `TEAMS_WEBHOOK_URL` - Optional. If specified, the content of `/var/log/backup-last.log` is sent to your Microsoft Teams channel after each backup.
 * `MAILX_ARGS` - Optional. If specified, the content of `/var/log/backup-last.log` is sent via mail after each backup using an *external SMTP*. To have maximum flexibility, you have to specify the mail/smtp parameters by your own. Have a look at the [mailx manpage](https://linux.die.net/man/1/mailx) for further information. Example value: `-e "MAILX_ARGS=-r 'from@example.de' -s 'Result of the last restic backup run' -S smtp='smtp.example.com:587' -S smtp-use-starttls -S smtp-auth=login -S smtp-auth-user='username' -S smtp-auth-password='password' 'to@example.com'"`.
 * `OS_AUTH_URL` - Optional. When using restic with OpenStack Swift container.
 * `OS_PROJECT_ID` - Optional. When using restic with OpenStack Swift container.

--- a/backup.sh
+++ b/backup.sh
@@ -2,6 +2,7 @@
 
 lastLogfile="/var/log/backup-last.log"
 lastMailLogfile="/var/log/mail-last.log"
+lastMicrosoftTeamsLogfile="/var/log/microsoft-teams-last.log"
 
 copyErrorLog() {
   cp ${lastLogfile} /var/log/backup-error-last.log
@@ -58,6 +59,18 @@ fi
 
 end=`date +%s`
 echo "Finished Backup at $(date +"%Y-%m-%d %H:%M:%S") after $((end-start)) seconds"
+
+if [ -n "${TEAMS_WEBHOOK_URL}" ]; then
+    teamsTitle="Restic Last Backup Log"
+    teamsMessage=$( cat ${lastLogfile} | sed 's/"/\"/g' | sed "s/'/\'/g" | sed ':a;N;$!ba;s/\n/\n\n/g' )
+    teamsReqBody="{\"title\": \"${teamsTitle}\", \"text\": \"${teamsMessage}\" }"
+    sh -c "curl -H 'Content-Type: application/json' -d '${teamsReqBody}' '${TEAMS_WEBHOOK_URL}' > ${lastMicrosoftTeamsLogfile} 2>&1"
+    if [ $? == 0 ]; then
+        echo "Microsoft Teams notification successfully sent."
+    else
+        echo "Sending Microsoft Teams notification FAILED. Check ${lastMicrosoftTeamsLogfile} for further information."
+    fi
+fi
 
 if [ -n "${MAILX_ARGS}" ]; then
     sh -c "mailx -v -S sendwait ${MAILX_ARGS} < ${lastLogfile} > ${lastMailLogfile} 2>&1"


### PR DESCRIPTION
I just added **Microsoft Teams** as a notification channel just like the mail notification.

To use this notification, user must provide their Webhook URL in an environment variable called  `TEAMS_WEBHOOK_URL`. Then it sends the last backup log via a `curl` request to the desired team after each backup.

Notification preview:
![image](https://user-images.githubusercontent.com/12012168/96352934-765f4b80-10d4-11eb-8c38-9354e1fe8a67.png)


Feel free to make any change.

Thanks.