### PR TITLE
Add support for webhooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/
 
 FROM restic/restic:0.9.6
 
-# install mailx
-RUN apk add --update --no-cache heirloom-mailx fuse
+RUN apk add --update --no-cache heirloom-mailx fuse curl
 
 COPY --from=rclone /bin/rclone /bin/rclone
 

--- a/backup.sh
+++ b/backup.sh
@@ -69,7 +69,7 @@ fi
 
 if [ -f "/hooks/post-backup.sh" ]; then
     echo "Starting post-backup script ..."
-    /hooks/post-backup.sh
+    /hooks/post-backup.sh $backupRC
 else
     echo "Post-backup script not found ..."
 fi

--- a/backup.sh
+++ b/backup.sh
@@ -31,18 +31,17 @@ logLast "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}"
 
 # Do not save full backup log to logfile but to backup-last.log
 restic backup /data ${RESTIC_JOB_ARGS} --tag=${RESTIC_TAG?"Missing environment variable RESTIC_TAG"} >> ${lastLogfile} 2>&1
-rc=$?
+backupRC=$?
 logLast "Finished backup at $(date)"
-if [[ $rc == 0 ]]; then
-    echo "Backup Successfull" 
+if [[ $backupRC == 0 ]]; then
+    echo "Backup Successfull"
 else
-    echo "Backup Failed with Status ${rc}"
+    echo "Backup Failed with Status ${backupRC}"
     restic unlock
     copyErrorLog
-    exit 1
 fi
 
-if [ -n "${RESTIC_FORGET_ARGS}" ]; then
+if [[ $backupRC == 0 ]] && [ -n "${RESTIC_FORGET_ARGS}" ]; then
     echo "Forget about old snapshots based on RESTIC_FORGET_ARGS = ${RESTIC_FORGET_ARGS}"
     restic forget ${RESTIC_FORGET_ARGS} >> ${lastLogfile} 2>&1
     rc=$?


### PR DESCRIPTION
This pull request adds support for triggering webhooks from the `post-backup.sh` hook using curl.

Instead of adding support for a specific platform (Teams, Slack, etc.) using environment variables, this just makes it possible to call curl from the `post-backup.sh` hook. Most likely users will want to control the formatting of messages which requires platform specific code. The hook also gets a parameter (return code of the restic backup command) so the user can decide if they want notifications always or only on failure.

Also removed the `exit 1` when backup fails since it prevented notifications on backup failure. If a backup fails, we especially want to be notified about it.

