### PR TITLE
Fix minor typos in log output of backup.sh

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -35,7 +35,7 @@ restic backup /data ${RESTIC_JOB_ARGS} --tag=${RESTIC_TAG?"Missing environment v
 backupRC=$?
 logLast "Finished backup at $(date)"
 if [[ $backupRC == 0 ]]; then
-    echo "Backup Successfull"
+    echo "Backup Successful"
 else
     echo "Backup Failed with Status ${backupRC}"
     restic unlock
@@ -48,7 +48,7 @@ if [[ $backupRC == 0 ]] && [ -n "${RESTIC_FORGET_ARGS}" ]; then
     rc=$?
     logLast "Finished forget at $(date)"
     if [[ $rc == 0 ]]; then
-        echo "Forget Successfull"
+        echo "Forget Successful"
     else
         echo "Forget Failed with Status ${rc}"
         restic unlock


### PR DESCRIPTION
Hi lobaro, I just fixed a minor typo in the log output of `backup.sh` (~~Successfull~~ --> Successful).
Have a great day!