### PR TITLE
Update to restic 0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:latest as rclone
 ADD https://downloads.rclone.org/rclone-current-linux-amd64.zip /
 RUN unzip rclone-current-linux-amd64.zip && mv rclone-*-linux-amd64/rclone /bin/rclone && chmod +x /bin/rclone
 
-FROM restic/restic:0.12.0
+FROM restic/restic:0.13.0
 
 RUN apk add --update --no-cache heirloom-mailx fuse curl
 


### PR DESCRIPTION
Update the image to use restic 0.13: https://github.com/restic/restic/releases/v0.13.0