### PR TITLE
Adds support for using docker-cli and bash within the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 
 FROM docker.io/restic/restic:0.18.0
 
-RUN apk add --update --no-cache curl mailx shadow
+RUN apk add --update --no-cache bash curl docker-cli mailx shadow
 
 COPY --from=rclone /bin/rclone /bin/rclone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 
 FROM docker.io/restic/restic:0.18.0
 
-RUN apk add --update --no-cache bash curl docker-cli mailx shadow
+RUN apk add --update --no-cache bash curl docker-cli mailx shadow tzdata
 
 COPY --from=rclone /bin/rclone /bin/rclone
 
@@ -27,6 +27,7 @@ ENV RESTIC_REPOSITORY=/mnt/restic
 ENV RESTIC_PASSWORD=""
 ENV RESTIC_TAG=""
 ENV NFS_TARGET=""
+ENV TZ="UTC"
 ENV BACKUP_CRON="0 */6 * * *"
 ENV CHECK_CRON=""
 ENV RESTIC_INIT_ARGS=""

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ The container is set up by setting [environment variables](https://docs.docker.c
 * `RESTIC_PASSWORD` - the password for the restic repository. Will also be used for restic init during first start when the repository is not initialized.
 * `RESTIC_TAG` - Optional. To tag the images created by the container.
 * `NFS_TARGET` - Optional. If set, the given NFS is mounted, i.e. `mount -o nolock -v ${NFS_TARGET} /mnt/restic`. `RESTIC_REPOSITORY` must remain its default value!
-* `BACKUP_CRON` - A cron expression to run the backup. Note: The cron daemon uses UTC time zone. Default: `0 */6 * * *` aka every 6 hours.
-* `CHECK_CRON` - Optional. A cron expression to run data integrity check (`restic check`). If left unset, data will not be checked. Note: The cron daemon uses UTC time zone. Example: `0 23 * * 3` to run 11PM every Tuesday.
+* `BACKUP_CRON` - A cron expression to run the backup. Note: The cron daemon uses UTC time zone by default unless you specify a timezone with `TZ`. Default: `0 */6 * * *` aka every 6 hours.
+* `CHECK_CRON` - Optional. A cron expression to run data integrity check (`restic check`). If left unset, data will not be checked. Note: The cron daemon uses UTC time zone by default unless you specify a timezone with `TZ`. Example: `0 23 * * 3` to run 11PM every Tuesday.
+* `TZ` - Optional. The timezone to use for cron expressions. Default: `UTC`. Example: `Europe/Berlin` or `America/New_York`. See [list of valid timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 * `RESTIC_FORGET_ARGS` - Optional. Only if specified, `restic forget` is run with the given arguments after each backup. Example value: `-e "RESTIC_FORGET_ARGS=--prune --keep-last 10 --keep-hourly 24 --keep-daily 7 --keep-weekly 52 --keep-monthly 120 --keep-yearly 100"`
 * `RESTIC_INIT_ARGS` - Optional. Allows specifying extra arguments to `restic init` such as a password file with `--password-file`.
 * `RESTIC_JOB_ARGS` - Optional. Allows specifying extra arguments to the backup job such as limiting bandwith with `--limit-upload` or excluding file masks with `--exclude`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker pull ghcr.io/lobaro/restic-backup-docker:latest
 ```
 
 # Contributing
-Pull Requests to improve the image are always wellcome. Please create an issue about the PR first.
+Pull Requests to improve the image are always welcome. Please create an issue about the PR first.
 
 When behaviour of the image changes (Features, Bugfixes, Changes in the API) please update the "Unreleased" section of the [CHANGELOG.md](https://github.com/lobaro/restic-backup-docker/blob/master/CHANGELOG.md)
 
@@ -147,6 +147,7 @@ The container is set up by setting [environment variables](https://docs.docker.c
 ## Volumes
 
 * `/data` - This is the data that gets backed up. Just [mount](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems) it to wherever you want.
+* `/var/run/docker.sock` - (optional) Mount the docker socket to interact with docker on your host (e.g. stopping containers before backing them up)
 
 ## Set the hostname
 

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,6 @@ docker run --privileged --name backup-test \
 -e "RESTIC_FORGET_ARGS=--keep-last 10" \
 -v ~/test-data:/data \
 -v ~/test-repo/:/mnt/restic \
+-v /var/run/docker.sock:/var/run/docker.sock \
 -t restic-backup
-
 


### PR DESCRIPTION
This PR adds support for being able to use the docker cli and bash from within the container.

This is especially useful if you'd like to stop your containers before performing a backup to avoid data corruption (and restarting them afterward)

Also added bash support to be able to use bash syntax in pre/post backup scripts