### PR TITLE
feat: add restic check after forget with prune

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -48,6 +48,8 @@ else
     copyErrorLog
 fi
 
+forgetSuccess=false
+
 if [[ $backupRC == 0 ]] && [ -n "${RESTIC_FORGET_ARGS}" ]; then
     echo "Forget about old snapshots based on RESTIC_FORGET_ARGS = ${RESTIC_FORGET_ARGS}"
     restic forget ${RESTIC_FORGET_ARGS} >> ${lastLogfile} 2>&1
@@ -55,8 +57,27 @@ if [[ $backupRC == 0 ]] && [ -n "${RESTIC_FORGET_ARGS}" ]; then
     logLast "Finished forget at $(date)"
     if [[ $rc == 0 ]]; then
         echo "Forget Successful"
+        forgetSuccess=true
     else
         echo "Forget Failed with Status ${rc}"
+        restic unlock
+        forgetSuccess=false
+        copyErrorLog
+    fi
+fi
+
+echo "$RESTIC_FORGET_ARGS" | grep -q prune
+wasPruneRC=$?
+
+if [ "$forgetSuccess" = true ] && [ $wasPruneRC -eq 0 ]; then
+    echo "Checking repository after forget / prune"
+    restic check >> ${lastLogfile} 2>&1
+    rc=$?
+    logLast "Finished check at $(date)"
+    if [ $rc = 0 ]; then
+        echo "Check Successful"
+    else
+        echo "Check Failed with Status ${rc}"
         restic unlock
         copyErrorLog
     fi


### PR DESCRIPTION
Do a restic check after 'forget --prune' was called.
This is encourage by the documentation to ensure a clean repository state.

https://restic.readthedocs.io/en/stable/060_forget.html#remove-a-single-snapshot